### PR TITLE
Add options to ignore whitespaces and newlines mismatch.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,5 @@ crashlytics.properties
 crashlytics-build.properties
 fabric.properties
 
+# VS Code
+/.vscode/

--- a/README.rst
+++ b/README.rst
@@ -25,13 +25,15 @@ Usage
     Functional Testing Utility for Command-Line Applications
 
     positional arguments:
-      tests_dir   Path to the directory containing test cases
-      cmd         Path to the command to be tested
-      args        The command-line arguments with an ampersand character '@'
-                  markingwhere arguments from test.json should be injected
+      tests_dir      Path to the directory containing test cases
+      cmd            Path to the command to be tested
+      args           The command-line arguments with an ampersand character '@' markingwhere arguments from test.json should be injected
 
     optional arguments:
-      -h, --help  show this help message and exit
+      -h, --help     show this help message and exit
+      -b, --bw       black & white output
+      -u, --to-unix  convert CR+LF to LF in cmd output and test files
+      -t, --rtrim    ignore trailing whitespaces at the end of each line as well as trailing newlines
 
 Command-line arguments for test cases can be specified by creating a special file named ``tests.json``, and placing it in the directory containing your test cases. This ``tests.json`` file maps test cases to objects representing command-line arguments for that test case. If a command-line argument is a non-string value (e.g. a complex JavaScript object), the argument is stringified (with Python's ``json.dumps``), and passed in as JSON.
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup
 
-version = '2.0.1'
+version = '2.0.2'
 repo_url = 'https://github.com/arjun-menon/test_cmd'
 download_url = repo_url + '/tarball/' + version
 


### PR DESCRIPTION
There are two issues I encountered when using this tool:

1. There may be trailing spaces in the end of line, and trailing newlines in the end of output. They're invisible in testing error message, and it is problematic to find where the mismatch occured. I suggest to add an option `-t`/`--rtrim` to ignore such kind of mismatch.
2. When running black box tests on Windows they may fail because of newline mismatch. Windows uses `\r\n` as newline while Unixes use simply `\n`. Depending on environment where Python is running (Native or MSYS2) and Git settings (to convert `\n` to `\r\n` on fetch, or not) there may be different newlines both in reference files and black box output. It's hard to keep track this kind of error so I suggest to add an option `-u`/`--to-unix` that automatically converts Windows newlines to Unix ones.

*The current solution will provide bad results on occurrence of some multi-byte Unicode characters that contain sequences that could be misidentified as trailing spaces or Windows newlines, because current version of the tool compares bytes instead of strings. I can't suggest a simple solution because the encoding of program output could be arbitrary. So, for now, it's up to user to assure the absence of such Unicode characters in the tests when using `-t`/`-u` options.*

It would be nice if you review the changes. I hope the PR would be helpful.